### PR TITLE
34 catalog pagination backend

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -20,6 +20,11 @@ const isISODate = (str) => {
   }
 };
 
+// dependency for catalog.js
+const isInteger = (value) => {
+  return value && /^\d+$/.test(value);
+};
+
 const isObject = (o) => {
   return o === Object(o) && !isArray(o) && typeof o !== 'function' && !isISODate(o);
 };
@@ -52,4 +57,4 @@ const keysToCamel = (data) => {
   return data;
 };
 
-module.exports = { keysToCamel };
+module.exports = { keysToCamel, isInteger };

--- a/routes/catalog.js
+++ b/routes/catalog.js
@@ -1,14 +1,18 @@
 const express = require('express');
-
 const { db } = require('../server/db');
 
 const catalogRouter = express.Router();
-const { keysToCamel } = require('../common/utils');
+const { keysToCamel, isInteger } = require('../common/utils');
 
 // -- GET - Returns all data from the catalog table
 catalogRouter.get('/', async (req, res) => {
   try {
-    const allInfo = await db.query(`SELECT * from catalog;`);
+    let { limit, page } = req.query;
+    limit = isInteger(limit) ? parseInt(limit, 10) : 10;
+    page = isInteger(page) ? parseInt(page, 10) : 1;
+
+    const offset = (page - 1) * limit;
+    const allInfo = await db.query(`SELECT * from catalog LIMIT $1 OFFSET $2;`, [limit, offset]);
     res.status(200).json(keysToCamel(allInfo));
   } catch (err) {
     res.status(500).send(err.message);

--- a/routes/catalog.js
+++ b/routes/catalog.js
@@ -13,7 +13,8 @@ catalogRouter.get('/', async (req, res) => {
 
     const offset = (page - 1) * limit;
     const allInfo = await db.query(`SELECT * from catalog LIMIT $1 OFFSET $2;`, [limit, offset]);
-    res.status(200).json(keysToCamel(allInfo));
+    const eventCount = await db.query(`SELECT COUNT(DISTINCT id) from catalog;`);
+    res.status(200).json(keysToCamel({ events: allInfo, count: eventCount }));
   } catch (err) {
     res.status(500).send(err.message);
   }

--- a/routes/catalog.js
+++ b/routes/catalog.js
@@ -8,14 +8,14 @@ const { keysToCamel, isInteger } = require('../common/utils');
 catalogRouter.get('/', async (req, res) => {
   try {
     const { title, eventType, subject, season, year } = req.query;
-    
+
     let { limit, page } = req.query;
     limit = isInteger(limit) ? parseInt(limit, 10) : 10;
     page = isInteger(page) ? parseInt(page, 10) : 1;
 
     const offset = (page - 1) * limit;
-    
-    let query = 'FROM catalog WHERE 1=1';
+
+    let query = ' FROM catalog WHERE 1=1';
 
     const params = [];
 
@@ -53,21 +53,16 @@ catalogRouter.get('/', async (req, res) => {
     } else {
       params.push('');
     }
+
+    const eventCount = await db.query(`SELECT COUNT(*) ${query};`, params);
+
+    query += ' ORDER BY title ASC LIMIT $6 OFFSET $7;';
     params.push(limit);
     params.push(offset);
 
-    query += ' ORDER BY title ASC';
-    
-    let countQuery = 'SELECT COUNT(*) ' + query + ';';
-    const eventCount = await db.query(query, params);
-    
-    query += ' LIMIT $6 OFFSET $7;';
-    query = 'SELECT * ' + query;
+    const reqInfo = await db.query(`SELECT * ${query}`, params);
 
-    const reqInfo = await db.query(query, params);
-    
     res.status(200).json(keysToCamel({ events: reqInfo, count: eventCount }));
-    
   } catch (err) {
     res.status(500).send(err.message);
   }


### PR DESCRIPTION
* Modified GET request of `/catalog` to return a JSON object with two keys: count (number of elements in the table) and events (event objects themselves)
* Added `limit` and `pages` parameters to GET request of `/catalog` route
* Added `isInteger` function, a dependency for pagination functionality

Closes #34 