### PR TITLE
49 update published schedule and day backend routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const email = require('./routes/nodeMailer');
 const app = express();
 
 const catalogRouter = require('./routes/catalog');
+const dayRouter = require('./routes/day');
 
 const PORT = process.env.PORT || 3001;
 
@@ -33,6 +34,7 @@ app.use('/users', users);
 app.use('/catalog', catalogRouter);
 app.use('/nodeMailer', email);
 app.use('/auth', authRouter);
+app.use('/day', dayRouter);
 
 app.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);

--- a/common/utils.js
+++ b/common/utils.js
@@ -26,9 +26,10 @@ const isInteger = (value) => {
 };
 
 // dependency for publishedSchedule.js
-const calculateYear = (gradeLevel) => {
+const calculateYear = (eventDate, gradeLevel) => {
   if (gradeLevel) {
-    const currentDay = new Date();
+    const currentDay = new Date(eventDate);
+    // console.log('current day', currentDay.getFullYear() + (currentDay.getMonth() >= 7 ? 2 : 1));
     if (gradeLevel.toLowerCase() === 'junior') {
       // if the current month is august or later
       // then junior will be current year + 2

--- a/common/utils.js
+++ b/common/utils.js
@@ -25,6 +25,33 @@ const isInteger = (value) => {
   return value && /^\d+$/.test(value);
 };
 
+// dependency for publishedSchedule.js
+const calculateYear = (gradeLevel) => {
+  if (gradeLevel) {
+    const currentDay = new Date();
+    if (gradeLevel.toLowerCase() === 'junior') {
+      // if the current month is august or later
+      // then junior will be current year + 2
+      // otherwise junior will be current year + 1
+      // months are zero indexed
+      return [(currentDay.getFullYear() + (currentDay.getMonth() >= 7 ? 2 : 1)).toString(10)];
+    }
+    if (gradeLevel.toLowerCase() === 'senior') {
+      // if the current month is august or later
+      // then senior will be current year + 1
+      // otherwise senior will be current year
+      return [(currentDay.getFullYear() + (currentDay.getMonth() >= 7 ? 1 : 0)).toString(10)];
+    }
+    if (gradeLevel.toLowerCase() === 'both') {
+      return [
+        (currentDay.getFullYear() + (currentDay.getMonth() >= 7 ? 1 : 0)).toString(10),
+        (currentDay.getFullYear() + (currentDay.getMonth() >= 7 ? 2 : 1)).toString(10),
+      ];
+    }
+  }
+  return [];
+};
+
 const isObject = (o) => {
   return o === Object(o) && !isArray(o) && typeof o !== 'function' && !isISODate(o);
 };
@@ -57,4 +84,4 @@ const keysToCamel = (data) => {
   return data;
 };
 
-module.exports = { keysToCamel, isInteger };
+module.exports = { keysToCamel, isInteger, calculateYear };

--- a/routes/day.js
+++ b/routes/day.js
@@ -1,0 +1,102 @@
+const express = require('express');
+const { db } = require('../server/db');
+const { keysToCamel } = require('../common/utils');
+
+const dayRouter = express.Router();
+
+// GET - returns all days in the table
+dayRouter.get('/', async (req, res) => {
+  try {
+    const allDays = await db.query(`SELECT * FROM day;`);
+    res.status(200).json(keysToCamel(allDays));
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
+});
+
+// GET - returns a day by eventDate parameter
+dayRouter.get('/date', async (req, res) => {
+  try {
+    const { eventDate } = req.query;
+    const dayByDate = await db.query(`SELECT * FROM day WHERE event_date = $1;`, [eventDate]);
+    res.status(200).json(keysToCamel(dayByDate));
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
+});
+
+// GET - returns a day by id
+dayRouter.get('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const dayById = await db.query(`SELECT * FROM day WHERE id = $1;`, [id]);
+    res.status(200).json(keysToCamel(dayById));
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
+});
+
+// POST - creates a new day
+dayRouter.post('/', async (req, res) => {
+  try {
+    const { eventDate, startTime, endTime, location, notes } = req.body;
+    const newDay = await db.query(
+      `
+      INSERT INTO day (
+        id,
+        event_date,
+        start_time,
+        end_time,
+        location,
+        notes
+      ) VALUES (
+        nextval('day_id_seq'), $1, $2, $3, $4, $5
+      ) RETURNING id;
+      `,
+      [eventDate, startTime, endTime, location, notes],
+    );
+    res.status(201).json({
+      status: 'Success',
+      id: newDay[0].id,
+    });
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
+});
+
+// PUT - modifies an existing day
+dayRouter.put('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { eventDate, startTime, endTime, location, notes } = req.body;
+    const updatedDay = await db.query(
+      `
+      UPDATE day
+      SET
+        event_date = COALESCE($1, event_date),
+        start_time = COALESCE($2, start_time),
+        end_time = COALESCE($3, end_time),
+        location = COALESCE($4, location),
+        notes = COALESCE($5, notes)
+      WHERE id = $6
+      RETURNING *;
+      `,
+      [eventDate, startTime, endTime, location, notes, id],
+    );
+    res.status(200).send(keysToCamel(updatedDay));
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
+});
+
+// DELETE - deletes an existing day
+dayRouter.delete('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const deletedDay = await db.query(`DELETE FROM day WHERE id = $1 RETURNING *;`, [id]);
+    res.status(200).send(keysToCamel(deletedDay));
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
+});
+module.exports = dayRouter;

--- a/routes/day.js
+++ b/routes/day.js
@@ -39,7 +39,7 @@ dayRouter.get('/:id', async (req, res) => {
 // POST - creates a new day
 dayRouter.post('/', async (req, res) => {
   try {
-    const { eventDate, startTime, endTime, location, notes } = req.body;
+    const { eventDate, location, notes } = req.body;
     const newDay = await db.query(
       `
       INSERT INTO day (
@@ -51,10 +51,10 @@ dayRouter.post('/', async (req, res) => {
         notes,
         day_count
       ) VALUES (
-        nextval('day_id_seq'), $1, $2, $3, $4, $5, 0
+        nextval('day_id_seq'), $1, '23:59:59', '00:00:00', $2, $3, 0
       ) RETURNING id;
       `,
-      [eventDate, startTime, endTime, location, notes],
+      [eventDate, location, notes],
     );
     res.status(201).json({
       status: 'Success',

--- a/routes/day.js
+++ b/routes/day.js
@@ -48,9 +48,10 @@ dayRouter.post('/', async (req, res) => {
         start_time,
         end_time,
         location,
-        notes
+        notes,
+        day_count
       ) VALUES (
-        nextval('day_id_seq'), $1, $2, $3, $4, $5
+        nextval('day_id_seq'), $1, $2, $3, $4, $5, 0
       ) RETURNING id;
       `,
       [eventDate, startTime, endTime, location, notes],

--- a/routes/publishedSchedule.js
+++ b/routes/publishedSchedule.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { db } = require('../server/db');
-const { keysToCamel } = require('../common/utils');
+const { keysToCamel, calculateYear } = require('../common/utils');
 
 const publishedScheduleRouter = express.Router();
 
@@ -235,7 +235,7 @@ publishedScheduleRouter.post('/', async (req, res) => {
           ($1, $2, $3, $4, $5, $6, $7, $8)
         RETURNING id;
       `,
-      [eventId, dayId, confirmed, confirmedOn, startTime, endTime, cohort, notes],
+      [eventId, dayId, confirmed, confirmedOn, startTime, endTime, calculateYear(cohort), notes],
     );
     res.status(201).json({
       status: 'Success',
@@ -267,7 +267,17 @@ publishedScheduleRouter.put('/:id', async (req, res) => {
 
       RETURNING *;
       `,
-      [eventId, dayId, confirmed, confirmedOn, startTime, endTime, cohort, notes, id],
+      [
+        eventId,
+        dayId,
+        confirmed,
+        confirmedOn,
+        startTime,
+        endTime,
+        calculateYear(cohort),
+        notes,
+        id,
+      ],
     );
     res.status(200).json(keysToCamel(updatedPublishedSchedule));
   } catch (err) {

--- a/routes/publishedSchedule.js
+++ b/routes/publishedSchedule.js
@@ -225,8 +225,8 @@ publishedScheduleRouter.post('/', async (req, res) => {
       `
       UPDATE day
         SET
-          start_time = CASE WHEN $1::timestamp < start_time THEN $1::timestamp ELSE start_time END,
-          end_time = CASE WHEN $2::timestamp > end_time THEN $2::timestamp ELSE end_time END
+          start_time = CASE WHEN $1 < start_time THEN $1 ELSE start_time END,
+          end_time = CASE WHEN $2 > end_time THEN $2 ELSE end_time END
         WHERE id = $3;
       `,
       [startTime, endTime, dayId],
@@ -392,14 +392,14 @@ publishedScheduleRouter.delete('/:id', async (req, res) => {
       await db.query(`DELETE FROM day WHERE id = $1`, [dayId]);
     } else {
       // if the event start time was the earliest change to earliest in PS table for that day
-      if (startTime.getTime() === dayResult.startTime.getTime()) {
+      if (startTime === dayResult.startTime) {
         await db.query(
           `UPDATE day SET start_time = (SELECT MIN(start_time) FROM published_schedule WHERE day_id = $1) WHERE id = $1`,
           [dayId],
         );
       }
       // if the event end time was the latest change to latest in PS table for that day
-      if (endTime.getTime() === dayResult.endTime.getTime()) {
+      if (endTime === dayResult.endTime) {
         await db.query(
           `UPDATE day SET end_time = (SELECT MAX(end_time) FROM published_schedule WHERE day_id = $1) WHERE id = $1`,
           [dayId],

--- a/server/schema/published_schedule.sql
+++ b/server/schema/published_schedule.sql
@@ -5,8 +5,8 @@ CREATE TABLE IF NOT EXISTS published_schedule (
     day_id integer NOT NULL,
     confirmed boolean NOT NULL,
     confirmed_on date NOT NULL,
-    start_time timestamp NOT NULL,
-    end_time timestamp NOT NULL,
+    start_time time NOT NULL,
+    end_time time NOT NULL,
     cohort varchar[] NOT NULL,
     notes varchar(100),
     FOREIGN KEY (event_id)

--- a/server/schema/published_schedule.sql
+++ b/server/schema/published_schedule.sql
@@ -14,3 +14,5 @@ CREATE TABLE IF NOT EXISTS published_schedule (
     FOREIGN KEY (day_id)
         REFERENCES day (id)
 );
+
+CREATE INDEX idx_day_id ON published_schedule (day_id);

--- a/server/schema/published_schedule.sql
+++ b/server/schema/published_schedule.sql
@@ -1,7 +1,8 @@
 DROP TABLE IF EXISTS published_schedule;
 CREATE TABLE IF NOT EXISTS published_schedule (
-    id serial NOT NULL,
+    id serial NOT NULL PRIMARY KEY,
     event_id integer NOT NULL,
+    day_id integer NOT NULL,
     confirmed boolean NOT NULL,
     confirmed_on date NOT NULL,
     start_time timestamp NOT NULL,
@@ -9,5 +10,7 @@ CREATE TABLE IF NOT EXISTS published_schedule (
     cohort varchar[] NOT NULL,
     notes varchar(100),
     FOREIGN KEY (event_id)
-        REFERENCES catalog (id)
+        REFERENCES catalog (id),
+    FOREIGN KEY (day_id)
+        REFERENCES day (id)
 );


### PR DESCRIPTION
Added basic day routes for CRUD operations.
Updated published schedule routes to work with the new day table.
Added calculations of grad year number given "junior", "senior" or "both" as a parameter; this is used in the `POST` and `PUT` routes.
Updated tables to match db model
Closes #49 